### PR TITLE
Do not insert path to config file

### DIFF
--- a/thoth/s2i/objs.py
+++ b/thoth/s2i/objs.py
@@ -279,7 +279,6 @@ class BuildConfig(OpenShiftObject):
         "THAMOS_VERBOSE": "0",
         "THAMOS_FORCE": "0",
         "THAMOS_DEBUG": "0",
-        "THAMOS_CONFIG_TEMPLATE": ".thoth.yaml",
         "THAMOS_CONFIG_EXPAND_ENV": "0",
         "THAMOS_NO_PROGRESSBAR": "1",
         "THAMOS_NO_INTERACTIVE": "1",


### PR DESCRIPTION
Otherwise expansion fails if the config file is not present. Thamos by default
uses a template shipped so use it for the initial setup.

## This introduces a breaking change

- [ ] Yes
- [x] No

