### PR TITLE
Long description is reStructuredText

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,4 +82,5 @@ setup(
     zip_safe=False,
     install_requires=get_install_requires(),
     cmdclass={"test": Test},
+    long_description_content_type="text/x-rst",
 )


### PR DESCRIPTION
## Related Issues and Dependencies

```
Checking dist/thoth-s2i-0.1.1.tar.gz: PASSED, with warnings
  warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
```

## This introduces a breaking change

- [ ] Yes
- [x] No
